### PR TITLE
Freezing point depression

### DIFF
--- a/olaf/main.py
+++ b/olaf/main.py
@@ -10,18 +10,19 @@ from olaf.processing.spaced_temp_csv import SpacedTempCSV
 
 # -----------------------------    USER INPUTS    -------------------------------------
 #test_folder = Path.cwd().parent / "tests" /"test_data" / "fpd" / "NSA no.2 05.22.25 base"
-test_folder = Path("D:/OLAF/Freezing point depression tests/capek mock test 12.31.24 base")
-#test_folder = Path("G:/Shared drives/INP Mentor/Current Data Processing/CAPE_k/QAQC as of 03.04.26_CH/2024/KCG 09.23.24 peroxide bl")
-site = "na"
-start_time = "2024-12-31 04:05:00"
-end_time = "2024-12-31 04:05:00"
+#test_folder = Path("D:/INP Mentor/IOPs/TRACER/Swarup China S3 Heat treatments/HOU S3 07.25.22 base")
+#test_folder = Path("G:/Shared drives/INP Mentor/Current Data Processing/CoURAGE/Ground/QAQC as of 04.10.26 CH/(M1) 08.12.25 base rerun")
+test_folder = Path("D:OLAF/Freezing point depression tests/RAM_CINC A12 07.16.25 base")
+site = "CRG_M1"
+start_time = "2025-07-16 16:20:00"
+end_time = " 2025-07-16 17:52:00"
 filter_color = "white"
-notes = "testing"
-user = "Carson"
-IS = "na"
+notes = "none"
+user = "Oren/Carson"
+IS = "IS2"
 num_samples = 6  # In the file
 sample_type = "salt"  # air, liquid or soil
-vol_air_filt = 1.0 # L
+vol_air_filt = 1 # L
 wells_per_sample = 32
 proportion_filter_used = 1.0  # between 0 and 1.0
 vol_susp = 10  # mL
@@ -47,10 +48,10 @@ dict_samples_to_dilution = {
 # Use for side B
 # dict_samples_to_dilution = {
 #     "Sample_5": 1.5,
-#     "Sample_4": 16.5,
-#     "Sample_3": 181.5,
-#     "Sample_2": 1996.5,
-#     #"Sample_1": 14641,
+#     "Sample_4": 19.5,
+#     "Sample_3": 253.5,
+#     "Sample_2": 3295.5,
+#     "Sample_1": 42841.5,
 #     "Sample_0": float("inf"),
 # }
 
@@ -64,7 +65,7 @@ dry_mass = 2  # dried mass of soil in g
 
 # if seawater or other salty sample, use this to estimate freezing point depression
 # use this formula: {dilution:adjustment}
-freezing_point_depression_dict = {1:2, 11:0.2}
+freezing_point_depression_dict = {"Sample_0":2, "Sample_1":0.2}
 
 
 # ----------------------- Assembling the header for the CSV file -----------------------
@@ -100,22 +101,25 @@ if __name__ == "__main__":
     if "TBS" in site:
         header += f"lower_altitude = {lower_altitude}\nupper_altitude = {upper_altitude}\n"
 
-
-    # GUI
-    window = tk.Tk()
-    app = FreezingReviewer(
-        window,
-        test_folder,
-        num_samples,
-        wells_per_sample,
-        dict_samples_to_dilution,
-        includes=treatment,
-    )
-    window.mainloop()
-
+    #GUI
+    # window = tk.Tk()
+    # app = FreezingReviewer(
+    #     window,
+    #     test_folder,
+    #     num_samples,
+    #     wells_per_sample,
+    #     dict_samples_to_dilution,
+    #     includes=treatment,
+    # )
+    # window.mainloop()
+    #
     # # Processing to create .csv file
     spaced_temp_csv = SpacedTempCSV(test_folder, num_samples, includes=treatment)
-    spaced_temp_csv.create_temp_csv(dict_samples_to_dilution)
+    spaced_temp_csv.create_temp_csv(
+        dict_samples_to_dilution,
+        freezing_point_depression_dict,
+        wells_per_sample,
+        sample_type)
 
     # Processing to create INPs/L
     # Use regular expression to check for dates in folder name:

--- a/olaf/main.py
+++ b/olaf/main.py
@@ -13,7 +13,7 @@ from olaf.processing.spaced_temp_csv import SpacedTempCSV
 #test_folder = Path("D:/INP Mentor/IOPs/TRACER/Swarup China S3 Heat treatments/HOU S3 07.25.22 base")
 #test_folder = Path("G:/Shared drives/INP Mentor/Current Data Processing/CoURAGE/Ground/QAQC as of 04.10.26 CH/(M1) 08.12.25 base rerun")
 test_folder = Path("D:OLAF/Freezing point depression tests/RAM_CINC A12 07.16.25 base")
-site = "CRG_M1"
+site = "RAM_CINC"
 start_time = "2025-07-16 16:20:00"
 end_time = " 2025-07-16 17:52:00"
 filter_color = "white"
@@ -151,7 +151,6 @@ if __name__ == "__main__":
             proportion_filter_used,
             vol_susp,
             dict_samples_to_dilution,
-            freezing_point_depression_dict,
             includes=includes,
         )
         graph_data_csv.convert_INPs_L(header, show_plot=True)

--- a/olaf/processing/graph_data_csv.py
+++ b/olaf/processing/graph_data_csv.py
@@ -8,7 +8,6 @@ import pandas as pd
 from olaf.CONSTANTS import AGRESTI_COULL_UNCERTAIN_VALUES, NUM_TO_REPLACE_D1, VOL_WELL, Z
 from olaf.utils.data_handler import DataHandler
 from olaf.utils.df_utils import header_to_dict
-from olaf.utils.math_utils import freezing_point_depression
 from olaf.utils.plot_utils import plot_INPS_L
 
 
@@ -31,7 +30,6 @@ class GraphDataCSV(DataHandler):
         filter_used: float,
         vol_susp: float,
         dict_samples_to_dilution: dict,
-        freezing_point_depression_dict: dict,
         suffix: str = ".csv",
         includes: tuple = ("base",),
         excludes: tuple = ("INPs_L", "dict"),
@@ -54,7 +52,6 @@ class GraphDataCSV(DataHandler):
         self.filter_used = filter_used
         self.vol_susp = vol_susp
         self.dict_to_samples_dilution = dict_samples_to_dilution
-        self.freezing_point_depression_dict = freezing_point_depression_dict
         # change the headers of the data from samples to dilution factor
         try:
             # Store original column names for verification
@@ -296,47 +293,10 @@ class GraphDataCSV(DataHandler):
         # Add the temperature back as first column
         result_df.insert(0, "degC", temps)
 
-        "--------- Step 6: Correct for freezing point depression if necessary----------"
-        # if "salt" in self.sample_type or "sea water" in self.sample_type:
-        #     freezing_point_depression(self.freezing_point_depression_dict, result_df)
-        #     result_df["degC"] = result_df["degC"].round(decimals=1)
-        #     # this currently just picks the higher INP value where temps overlap
-        #     #TODO: Figure out why the dicts are being saved weird
-            #  TODO: Reinstate the 0.5 degree clean up
-            #  TODO: Make sure there are only four rows of empty data once this is finished
-        #     result_df = (result_df
-        #                  .sort_values("INPS_L", ascending=False)
-        #                  .drop_duplicates(subset="degC", keep="first")
-        #                  .sort_values("degC", ascending=False)
-        #                  .reset_index(drop=True))
-        #     # filter dataframe to take 0.5 temp intervals beside first freezer
-        #     first_five_rows = result_df.iloc[:5]
-        #     remaining_rows = result_df.iloc[5:]
-        #     filtered_rows = remaining_rows[remaining_rows.loc[:,"degC"] % 0.5 == 0]
-        #     result_df = pd.concat([first_five_rows, filtered_rows]).reset_index(drop=True)
-            # save freezing point depression dictionary to csv file
-        fpd_dict_df = pd.DataFrame.from_dict(
-            self.freezing_point_depression_dict,
-            orient="index",
-            columns=["temp_adjustment"])
-        fpd_dict_df.index.name = "dilution"
-        fpd_dict_df = fpd_dict_df.reset_index()
-        self.save_to_new_file(fpd_dict_df, self.folder_path /
-                              f"{self.data_file}.csv", "frz_pnt_dep_dict")
-
-
-        "---------------------- Step 7: Save and return the data ----------------------"
+        "---------------------- Step 6: Save and return the data ----------------------"
         if save:
             self.save_to_new_file(result_df, prefix="INPs_L", header=header)
-            # convert dilution dict to df then save as new csv file
-            dilution_dict_df = pd.DataFrame.from_dict(
-                self.dict_to_samples_dilution,
-                orient="index",
-                columns=["dilution"])
-            dilution_dict_df.index.name = "sample"
-            dilution_dict_df = dilution_dict_df.reset_index()
-            self.save_to_new_file(dilution_dict_df, self.folder_path /
-                                  f"{self.data_file}.csv", "dilution_dict")
+
         # Plotting option
         if show_plot:
             header_dict = header_to_dict(header)

--- a/olaf/processing/graph_data_csv.py
+++ b/olaf/processing/graph_data_csv.py
@@ -86,7 +86,7 @@ class GraphDataCSV(DataHandler):
         """
         Convert from # frozen wells at temperature for certain dilution to INPs/L.
         The steps involved in this function are:
-        1. Seperate the temperature and # frozen well values.
+        1. Separate the temperature and # frozen well values.
         2. Create a column with the total number of wells per temperature
         as affected by the background.
         3. Calculate the INPs/L and the confidence intervals. It does this by using the
@@ -114,7 +114,9 @@ class GraphDataCSV(DataHandler):
 
         """
 
-        # Internal logic function for later use
+
+
+            # Internal logic function for later use
         def error_logic_selecting_values(i, col_name, next_dilution_INP):
             """
             Logic for selecting the values to keep in the result_df when both current
@@ -295,30 +297,32 @@ class GraphDataCSV(DataHandler):
         result_df.insert(0, "degC", temps)
 
         "--------- Step 6: Correct for freezing point depression if necessary----------"
-        if "salt" in self.sample_type or "sea water" in self.sample_type:
-            freezing_point_depression(self.freezing_point_depression_dict, result_df)
-            result_df["degC"] = result_df["degC"].round(decimals=1)
-            # this currently just picks the higher INP value where temps overlap
-            #TODO: Decide if we make dilution decision a function to call again here
-            result_df = (result_df
-                         .sort_values("INPS_L", ascending=False)
-                         .drop_duplicates(subset="degC", keep="first")
-                         .sort_values("degC", ascending=False)
-                         .reset_index(drop=True))
-            # filter dataframe to take 0.5 temp intervals beside first freezer
-            first_five_rows = result_df.iloc[:5]
-            remaining_rows = result_df.iloc[5:]
-            filtered_rows = remaining_rows[remaining_rows.loc[:,"degC"] % 0.5 == 0]
-            result_df = pd.concat([first_five_rows, filtered_rows]).reset_index(drop=True)
+        # if "salt" in self.sample_type or "sea water" in self.sample_type:
+        #     freezing_point_depression(self.freezing_point_depression_dict, result_df)
+        #     result_df["degC"] = result_df["degC"].round(decimals=1)
+        #     # this currently just picks the higher INP value where temps overlap
+        #     #TODO: Figure out why the dicts are being saved weird
+            #  TODO: Reinstate the 0.5 degree clean up
+            #  TODO: Make sure there are only four rows of empty data once this is finished
+        #     result_df = (result_df
+        #                  .sort_values("INPS_L", ascending=False)
+        #                  .drop_duplicates(subset="degC", keep="first")
+        #                  .sort_values("degC", ascending=False)
+        #                  .reset_index(drop=True))
+        #     # filter dataframe to take 0.5 temp intervals beside first freezer
+        #     first_five_rows = result_df.iloc[:5]
+        #     remaining_rows = result_df.iloc[5:]
+        #     filtered_rows = remaining_rows[remaining_rows.loc[:,"degC"] % 0.5 == 0]
+        #     result_df = pd.concat([first_five_rows, filtered_rows]).reset_index(drop=True)
             # save freezing point depression dictionary to csv file
-            fpd_dict_df = pd.DataFrame.from_dict(
-                self.freezing_point_depression_dict,
-                orient="index",
-                columns=["temp_adjustment"])
-            fpd_dict_df.index.name = "dilution"
-            fpd_dict_df = fpd_dict_df.reset_index()
-            self.save_to_new_file(fpd_dict_df, self.folder_path /
-                                  f"{self.data_file}.csv", "frz_pnt_dep_dict")
+        fpd_dict_df = pd.DataFrame.from_dict(
+            self.freezing_point_depression_dict,
+            orient="index",
+            columns=["temp_adjustment"])
+        fpd_dict_df.index.name = "dilution"
+        fpd_dict_df = fpd_dict_df.reset_index()
+        self.save_to_new_file(fpd_dict_df, self.folder_path /
+                              f"{self.data_file}.csv", "frz_pnt_dep_dict")
 
 
         "---------------------- Step 7: Save and return the data ----------------------"

--- a/olaf/processing/spaced_temp_csv.py
+++ b/olaf/processing/spaced_temp_csv.py
@@ -37,7 +37,7 @@ class SpacedTempCSV(DataHandler):
 
     def create_temp_csv(
         self,
-        dict_to_sample_dilution: dict,
+        dict_samples_to_dilution: dict,
         freezing_point_depression_dict: dict,
         wells_per_sample: int,
         sample_type: str,
@@ -62,10 +62,10 @@ class SpacedTempCSV(DataHandler):
         8. Save the data in a separate .csv file with the same name as the experiment.
         The data is saved in a separate .csv file with the same name as the experiment
         Args:
-            dict_to_sample_dilution:
-            freezing_point_depression_dict:
-            wells_per_sample:
-            sample_type:
+            dict_to_sample_dilution: dict from main
+            freezing_point_depression_dict: dict from main
+            wells_per_sample: variable from main
+            sample_type: variable from main
             temp_step: The interval of temperatures to save (default: 0.5)
             temp_col: The column in the data file that contains the temperature values
             save: Whether to save the data to a .csv file (default: True)
@@ -75,7 +75,7 @@ class SpacedTempCSV(DataHandler):
         # initialize the temp_frozen_df with temperature column and sample columns
         # step 1 and 2: Find least diluted sample from dict_to_sample_dilution
         least_diluted_sample = min(
-            dict_to_sample_dilution, key=lambda k: dict_to_sample_dilution[k]
+            dict_samples_to_dilution, key=lambda k: dict_samples_to_dilution[k]
         )
         first_frozen_id = self.data[least_diluted_sample].ne(0).idxmax()
         temp_frozen = round(pd.to_numeric(self.data.loc[first_frozen_id, temp_col]), 1)
@@ -87,7 +87,7 @@ class SpacedTempCSV(DataHandler):
         ]
         if sample_type == "salt" or sample_type == "sea water":
             least_diluted_sample_adjustment = freezing_point_depression_dict.get(least_diluted_sample)
-            num_empty_rows = round(10 * least_diluted_sample_adjustment)
+            num_empty_rows = round(10 * least_diluted_sample_adjustment + 4)
         else:
             num_empty_rows = 4
 
@@ -125,12 +125,13 @@ class SpacedTempCSV(DataHandler):
             temp_frozen_df.loc[len(temp_frozen_df)] = new_row
 
         temp_frozen_df["Avg_Temp"] = temp_frozen_df["Avg_Temp"].round(decimals=1)
-        # TODO: add fpd stuff here
+
+        # Move columns affected by freezing point depression to the corrected
+        # temperature indices
         if sample_type == "salt" or sample_type == "sea water":
             for key, value in freezing_point_depression_dict.items():
                 df_index_adjustment = value * 10
                 temp_frozen_df[key] = temp_frozen_df[key].shift(-int(df_index_adjustment))
-
 
         # Change temperature column to standard name of degC
         temp_frozen_df.rename(columns={temp_col: "degC"}, inplace=True)
@@ -139,10 +140,36 @@ class SpacedTempCSV(DataHandler):
             mask = temp_frozen_df[f"Sample_{i}"].isna()
             temp_frozen_df.loc[mask, f"Sample_{i}"] = wells_per_sample
             temp_frozen_df[f"Sample_{i}"] = temp_frozen_df[f"Sample_{i}"].astype("int64")
+
+        # filter dataframe to take 0.5 temp intervals beside first freezer
+        if sample_type == "salt" or sample_type == "sea water":
+            first_four_rows = temp_frozen_df.iloc[:4]
+            remaining_rows = temp_frozen_df.iloc[4:]
+            filtered_rows = remaining_rows[remaining_rows.loc[:,"degC"] % 0.5 == 0]
+            temp_frozen_df = pd.concat([first_four_rows, filtered_rows]).reset_index(drop=True)
+
         # step 8
         if save:
             self.save_to_new_file(
                 temp_frozen_df, self.folder_path / f"{self.data_file.stem}.csv", "frozen_at_temp"
             )
+            fpd_dict_df = pd.DataFrame.from_dict(
+                freezing_point_depression_dict,
+                orient="index",
+                columns=["temp_adjustment"])
+            fpd_dict_df.index.name = "dilution"
+            fpd_dict_df = fpd_dict_df.reset_index()
+            self.save_to_new_file(
+                fpd_dict_df, self.folder_path / f"{self.data_file.stem}.csv", "frz_pnt_dep_dict"
+            )
+            # convert dilution dict to df then save as new csv file
+            dilution_dict_df = pd.DataFrame.from_dict(
+                dict_samples_to_dilution,
+                orient="index",
+                columns=["dilution"])
+            dilution_dict_df.index.name = "sample"
+            dilution_dict_df = dilution_dict_df.reset_index()
+            self.save_to_new_file(dilution_dict_df, self.folder_path /
+                                  f"{self.data_file.stem}.csv", "dilution_dict")
 
         return temp_frozen_df

--- a/olaf/processing/spaced_temp_csv.py
+++ b/olaf/processing/spaced_temp_csv.py
@@ -15,6 +15,7 @@ class SpacedTempCSV(DataHandler):
         includes: tuple = ("base",),
         excludes: tuple = ("frozen",),
         date_col: str = "Date",
+        sample_type: str = "salt",
     ) -> None:
         """
         Class that has functionality to read a (processed ("verified")) well experiments
@@ -37,6 +38,9 @@ class SpacedTempCSV(DataHandler):
     def create_temp_csv(
         self,
         dict_to_sample_dilution: dict,
+        freezing_point_depression_dict: dict,
+        wells_per_sample: int,
+        sample_type: str,
         temp_step: float = TEMP_STEP,
         temp_col: str = "Avg_Temp",
         save: bool = True,
@@ -58,6 +62,10 @@ class SpacedTempCSV(DataHandler):
         8. Save the data in a separate .csv file with the same name as the experiment.
         The data is saved in a separate .csv file with the same name as the experiment
         Args:
+            dict_to_sample_dilution:
+            freezing_point_depression_dict:
+            wells_per_sample:
+            sample_type:
             temp_step: The interval of temperatures to save (default: 0.5)
             temp_col: The column in the data file that contains the temperature values
             save: Whether to save the data to a .csv file (default: True)
@@ -77,10 +85,18 @@ class SpacedTempCSV(DataHandler):
         temp_first_frozen_row = [temp_frozen] + [
             self.data.loc[first_frozen_id, f"Sample_{i}"] for i in range(self.num_samples)
         ]
+        if sample_type == "salt" or sample_type == "sea water":
+            least_diluted_sample_adjustment = freezing_point_depression_dict.get(least_diluted_sample)
+            num_empty_rows = round(10 * least_diluted_sample_adjustment)
+        else:
+            num_empty_rows = 4
+
         temp_frozen_df = pd.DataFrame(
-            data=[[round_temp_frozen + j * 0.5] + [0] * self.num_samples for j in range(4, 0, -1)],
+            data=[[round_temp_frozen + j * TEMP_STEP] + [0] *
+                  self.num_samples for j in range(num_empty_rows, 0, -1)],
             columns=[temp_col] + [f"Sample_{i}" for i in range(self.num_samples)],
         )
+
         temp_frozen_df.loc[len(temp_frozen_df)] = temp_first_frozen_row
         while round_temp_frozen - temp_step > min(self.data[temp_col]):
             # Step 6: increment the temperature by temp_step until the end of the data
@@ -108,10 +124,20 @@ class SpacedTempCSV(DataHandler):
 
             temp_frozen_df.loc[len(temp_frozen_df)] = new_row
 
+        temp_frozen_df["Avg_Temp"] = temp_frozen_df["Avg_Temp"].round(decimals=1)
+        # TODO: add fpd stuff here
+        if sample_type == "salt" or sample_type == "sea water":
+            for key, value in freezing_point_depression_dict.items():
+                df_index_adjustment = value * 10
+                temp_frozen_df[key] = temp_frozen_df[key].shift(-int(df_index_adjustment))
+
+
         # Change temperature column to standard name of degC
         temp_frozen_df.rename(columns={temp_col: "degC"}, inplace=True)
         # Set sample columns to ints
         for i in range(self.num_samples):
+            mask = temp_frozen_df[f"Sample_{i}"].isna()
+            temp_frozen_df.loc[mask, f"Sample_{i}"] = wells_per_sample
             temp_frozen_df[f"Sample_{i}"] = temp_frozen_df[f"Sample_{i}"].astype("int64")
         # step 8
         if save:

--- a/olaf/utils/math_utils.py
+++ b/olaf/utils/math_utils.py
@@ -12,9 +12,4 @@ def inps_L_to_ml(inps_col, vol_air_filt, prop_filter_used, vol_susp):
 def rms(x):
     return np.sqrt(np.mean(np.square(x)))
 
-def freezing_point_depression(freezing_point_depression_dict, result_df):
-    for key, value in freezing_point_depression_dict.items():
-        mask = result_df["dilution"] == key
-        result_df.loc[mask, "degC"] += value
-    return result_df
 


### PR DESCRIPTION
Changing this from a component of graph_data_csv to now be part of spaced_temp_csv. This is now much cleaner and simpler to read. 

Originally the freezing point depression correction was applied after the dilution logic by adjusting the temperature data for bins where a given dilution from the freezing_point_depression_dict was used. However, this caused missing data in between the neat and first dilution.

Now the adjustment is applied when creating the 0.5 degree freezing data file. Each column needing correction is moved up by the number of required indices as specified by the freezing point depression dict. I.e. if Sample_0 needs to be adjusted to be 2 degrees warmer, since the TEMP_STEP is 0.1, the data in the column Sample_0 and moved 20 indices higher, or two degrees. Any dilution not needing correction remains as is. Then near the end of the function the freezing data is constrained by 0.5 degree intervals. This can be changed manually if desired.